### PR TITLE
Unify examples style

### DIFF
--- a/docs/bloom.ts
+++ b/docs/bloom.ts
@@ -69,7 +69,7 @@ const sceneFbo = Framebuffer.create(dev, width, height, colorTex, depthTex);
 const pingFbo = Framebuffer.create(dev, blurWidth, blurHeight, pingTex);
 const pongFbo = Framebuffer.create(dev, blurWidth, blurHeight, pongTex);
 
-const view = mat4.create();
+const viewMatrix = mat4.create();
 
 // This vertex shader just renders one huge triangle to cover the screenspace.
 const screenspaceVS = `#version 300 es
@@ -129,16 +129,16 @@ const cmdDraw = Command.create<CmdDrawProps>(
 
         layout (location = 0) out vec4 f_color;
 
-        const vec3 u_color = vec3(0.1, 0.475, 0.811);
-        const float u_edge_thickness = 2.0;
-        const float u_edge_sharpness = 30.0;
-        const float u_edge_subtract	= 0.3;
+        const vec3 COLOR = vec3(0.1, 0.475, 0.811);
+        const float EDGE_THICKNESS = 2.0;
+        const float EDGE_SHARPNESS = 30.0;
+        const float EDGE_SUBTRACT = 0.3;
 
         void main() {
-            vec2 uv = abs(v_uv - 0.5) * u_edge_thickness;
-            uv = pow(uv, vec2(u_edge_sharpness)) - u_edge_subtract;
+            vec2 uv = abs(v_uv - 0.5) * EDGE_THICKNESS;
+            uv = pow(uv, vec2(EDGE_SHARPNESS)) - EDGE_SUBTRACT;
             float c = clamp(uv.x + uv.y, 0.0, 1.0) * u_glow_strength;
-            f_color	= vec4(u_color * c, 1.0);
+            f_color	= vec4(COLOR * c, 1.0);
         }
     `,
     {
@@ -150,7 +150,7 @@ const cmdDraw = Command.create<CmdDrawProps>(
             u_view: {
                 type: "matrix4fv",
                 value: ({ time }) => mat4.lookAt(
-                    view,
+                    viewMatrix,
                     [
                         200 * Math.cos(time / 9000),
                         155,
@@ -225,7 +225,7 @@ const cmdBlur = Command.create<CmdBlurProps>(
     `#version 300 es
         precision mediump float;
 
-        #define KERNEL_LENGTH ${KERNEL.length}
+        const int KERNEL_LENGTH = int(${KERNEL.length});
 
         uniform sampler2D u_image;
         uniform float[KERNEL_LENGTH] u_kernel;
@@ -316,7 +316,7 @@ const modelAttrs = Attributes.create(dev, uvCube.elements, {
 const HORIZONTAL = vec2.fromValues(1, 0);
 const VERTICAL = vec2.fromValues(0, 1);
 
-const loop = (time) => {
+const loop = (time: number): void => {
     // Render geometry into texture
     sceneFbo.target((rt) => {
         rt.clear(BufferBits.COLOR_DEPTH);

--- a/docs/deferred.ts
+++ b/docs/deferred.ts
@@ -28,7 +28,7 @@ import * as sponza from "./libx/sponza.js";
 import * as cube from "./libx/cube.js";
 
 const N_LIGHTS = 10;
-const DRAW_LIGHTS = true;
+const DRAW_LIGHTS = false;
 const LIGHT_ATTENUATION_CONSTANT = 1;
 const LIGHT_ATTENUATION_LINEAR = 0.14;
 const LIGHT_ATTENUATION_QUADRATIC = 0.07;
@@ -144,67 +144,67 @@ for (let i = 0; i < N_LIGHTS; ++i) {
 }
 
 interface CmdDrawGeometryProps {
-    proj: mat4;
-    view: mat4;
-    model: mat4;
+    projMatrix: mat4;
+    viewMatrix: mat4;
+    modelMatrix: mat4;
     material: Material;
 }
 
 const cmdDrawGeometry = Command.create<CmdDrawGeometryProps>(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        uniform mat4 u_proj, u_view, u_model;
+    uniform mat4 u_proj, u_view, u_model;
 
-        layout (location = 0) in vec3 a_position;
-        layout (location = 1) in vec3 a_normal;
+    layout (location = 0) in vec3 a_position;
+    layout (location = 1) in vec3 a_normal;
 
-        out vec3 v_position;
-        out vec3 v_normal;
+    out vec3 v_position;
+    out vec3 v_normal;
 
-        void main() {
-            v_position = (u_model * vec4(a_position, 1)).xyz;
-            v_normal = transpose(inverse(mat3(u_model))) * a_normal;
-            gl_Position = u_proj * u_view * u_model * vec4(a_position, 1);
-        }
+    void main() {
+        v_position = (u_model * vec4(a_position, 1)).xyz;
+        v_normal = transpose(inverse(mat3(u_model))) * a_normal;
+        gl_Position = u_proj * u_view * u_model * vec4(a_position, 1);
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        struct Material {
-            vec3 diffuse;
-            float specular;
-        };
+    struct Material {
+        vec3 diffuse;
+        float specular;
+    };
 
-        uniform Material u_material;
+    uniform Material u_material;
 
-        in vec3 v_position;
-        in vec3 v_normal;
+    in vec3 v_position;
+    in vec3 v_normal;
 
-        layout (location = 0) out vec4 f_color;
-        layout (location = 1) out vec4 f_position;
-        layout (location = 2) out vec4 f_normal;
+    layout (location = 0) out vec4 f_color;
+    layout (location = 1) out vec4 f_position;
+    layout (location = 2) out vec4 f_normal;
 
-        void main() {
-            f_color = vec4(u_material.diffuse, u_material.specular);
-            f_position = vec4(v_position, 1);
-            f_normal = vec4(normalize(v_normal), 0);
-        }
+    void main() {
+        f_color = vec4(u_material.diffuse, u_material.specular);
+        f_position = vec4(v_position, 1);
+        f_normal = vec4(normalize(v_normal), 0);
+    }
     `,
     {
         uniforms: {
             u_proj: {
                 type: "matrix4fv",
-                value: (props) => props.proj,
+                value: (props) => props.projMatrix,
             },
             u_view: {
                 type: "matrix4fv",
-                value: (props) => props.view,
+                value: (props) => props.viewMatrix,
             },
             u_model: {
                 type: "matrix4fv",
-                value: (props) => props.model,
+                value: (props) => props.modelMatrix,
             },
             "u_material.diffuse": {
                 type: "3f",
@@ -273,81 +273,81 @@ const createUniformOptions = (nLights: number): Uniforms<CmdDrawLightingProps> =
 const cmdDrawLighting = Command.create<CmdDrawLightingProps>(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        void main() {
-            switch (gl_VertexID % 3) {
-                case 0:
-                    gl_Position = vec4(-1, 3, 0, 1);
-                    break;
-                case 1:
-                    gl_Position = vec4(-1, -1, 0, 1);
-                    break;
-                case 2:
-                    gl_Position = vec4(3, -1, 0, 1);
-                    break;
-            }
+    void main() {
+        switch (gl_VertexID % 3) {
+            case 0:
+                gl_Position = vec4(-1, 3, 0, 1);
+                break;
+            case 1:
+                gl_Position = vec4(-1, -1, 0, 1);
+                break;
+            case 2:
+                gl_Position = vec4(3, -1, 0, 1);
+                break;
         }
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        #define N_LIGHTS ${N_LIGHTS}
+    const int N_LIGHTS = int(${N_LIGHTS});
 
-        struct Light {
-            vec3 position;
-            vec3 ambient;
-            vec3 diffuse;
-            vec3 specular;
-            float constant;
-            float linear;
-            float quadratic;
-        };
+    struct Light {
+        vec3 position;
+        vec3 ambient;
+        vec3 diffuse;
+        vec3 specular;
+        float constant;
+        float linear;
+        float quadratic;
+    };
 
-        uniform Light u_lights[N_LIGHTS];
-        uniform vec3 u_camera_position;
-        uniform sampler2D u_g_albedo_specular;
-        uniform sampler2D u_g_position;
-        uniform sampler2D u_g_normal;
+    uniform Light u_lights[N_LIGHTS];
+    uniform vec3 u_camera_position;
+    uniform sampler2D u_g_albedo_specular;
+    uniform sampler2D u_g_position;
+    uniform sampler2D u_g_normal;
 
-        out vec4 f_color;
+    out vec4 f_color;
 
-        void main() {
-            ivec2 coords = ivec2(gl_FragCoord.xy);
+    void main() {
+        ivec2 coords = ivec2(gl_FragCoord.xy);
 
-            vec3 diffuse = texelFetch(u_g_albedo_specular, coords, 0).rgb;
-            float specular = texelFetch(u_g_albedo_specular, coords, 0).a;
-            vec3 position = texelFetch(u_g_position, coords, 0).xyz;
-            vec3 normal = texelFetch(u_g_normal, coords, 0).xyz;
+        vec3 diffuse = texelFetch(u_g_albedo_specular, coords, 0).rgb;
+        float specular = texelFetch(u_g_albedo_specular, coords, 0).a;
+        vec3 position = texelFetch(u_g_position, coords, 0).xyz;
+        vec3 normal = texelFetch(u_g_normal, coords, 0).xyz;
 
-            vec3 view_dir = normalize(u_camera_position - position);
+        vec3 view_dir = normalize(u_camera_position - position);
 
-            vec3 lighting = diffuse * 0.1; // Hardcoded ambient
+        vec3 lighting = diffuse * 0.1; // Hardcoded ambient
 
-            for (int i = 0; i < N_LIGHTS; ++i) {
-                Light light = u_lights[i];
+        for (int i = 0; i < N_LIGHTS; ++i) {
+            Light light = u_lights[i];
 
-                float distance = length(light.position - position);
-                vec3 light_dir = normalize(light.position - position);
-                vec3 halfway_dir = normalize(view_dir + light_dir);
+            float distance = length(light.position - position);
+            vec3 light_dir = normalize(light.position - position);
+            vec3 halfway_dir = normalize(view_dir + light_dir);
 
-                float diffuse_f = max(dot(light_dir, normal), 0.0);
-                float specular_f = pow(
-                    max(dot(normal, halfway_dir), 0.0),
-                    16.0 // Hardcoded shininess
-                );
+            float diffuse_f = max(dot(light_dir, normal), 0.0);
+            float specular_f = pow(
+                max(dot(normal, halfway_dir), 0.0),
+                16.0 // Hardcoded shininess
+            );
 
-                float attenuation = 1.0 / (light.constant
-                    + light.linear * distance
-                    + light.quadratic * distance * distance
-                );
+            float attenuation = 1.0 / (light.constant
+                + light.linear * distance
+                + light.quadratic * distance * distance
+            );
 
-                lighting += attenuation * diffuse_f * light.diffuse * diffuse;
-                lighting += attenuation * specular_f * light.specular * specular;
-            }
-
-            f_color = vec4(lighting, 1);
+            lighting += attenuation * diffuse_f * light.diffuse * diffuse;
+            lighting += attenuation * specular_f * light.specular * specular;
         }
+
+        f_color = vec4(lighting, 1);
+    }
     `,
     {
         uniforms: createUniformOptions(N_LIGHTS),
@@ -370,29 +370,30 @@ interface CmdDrawLightProps {
 const cmdDrawLight = Command.create<CmdDrawLightProps>(
     dev,
     `#version 300 es
+    precision mediump float;
 
-        uniform mat4 u_proj, u_view, u_model;
-        uniform vec3 u_position;
+    uniform mat4 u_proj, u_view, u_model;
+    uniform vec3 u_position;
 
-        layout (location = 0) in vec3 a_position;
+    layout (location = 0) in vec3 a_position;
 
-        void main() {
-            gl_Position = u_proj
-                * u_view
-                * u_model
-                * vec4(a_position + u_position, 1.0);
-        }
+    void main() {
+        gl_Position = u_proj
+            * u_view
+            * u_model
+            * vec4(a_position + u_position, 1.0);
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        uniform vec3 u_color;
+    uniform vec3 u_color;
 
-        layout (location = 0) out vec4 f_color;
+    layout (location = 0) out vec4 f_color;
 
-        void main() {
-            f_color = vec4(u_color, 0.5);
-        }
+    void main() {
+        f_color = vec4(u_color, 0.5);
+    }
     `,
     {
         uniforms: {
@@ -458,9 +459,9 @@ const loop = (time: number): void => {
         rt.batch(cmdDrawGeometry, (draw) => {
             objects.forEach((object) => {
                 draw(object.attrs, {
-                    proj: projMatrix,
-                    view: viewMatrix,
-                    model: identity,
+                    projMatrix,
+                    viewMatrix,
+                    modelMatrix: identity,
                     material: object.material,
                 });
             });

--- a/docs/image-processing.ts
+++ b/docs/image-processing.ts
@@ -6,12 +6,7 @@
  * https://webgl2fundamentals.org/webgl/lessons/webgl-image-processing.html
  */
 
-import {
-    Device,
-    Command,
-    Attributes,
-    Texture,
-} from "./lib/webglutenfree.js";
+import { Device, Command, Attributes, Texture } from "./lib/webglutenfree.js";
 import { mat4 } from "./libx/gl-matrix.js";
 import { loadImage } from "./libx/load-image.js";
 
@@ -57,48 +52,48 @@ async function run() {
     const cmd = Command.create(
         dev,
         `#version 300 es
-            precision mediump float;
+        precision mediump float;
 
-            uniform mat4 u_projection, u_model;
+        uniform mat4 u_proj, u_model;
 
-            layout (location = 0) in vec2 a_position;
-            layout (location = 1) in vec2 a_uv;
+        layout (location = 0) in vec2 a_position;
+        layout (location = 1) in vec2 a_uv;
 
-            out vec2 v_uv;
+        out vec2 v_uv;
 
-            void main() {
-                v_uv = a_uv;
-                gl_Position = u_projection
-                    * u_model
-                    * vec4(a_position, 0.0, 1.0);
-            }
+        void main() {
+            v_uv = a_uv;
+            gl_Position = u_proj
+                * u_model
+                * vec4(a_position, 0.0, 1.0);
+        }
         `,
         `#version 300 es
-            precision mediump float;
+        precision mediump float;
 
-            uniform sampler2D u_image;
-            uniform float[9] u_kernel;
-            uniform float u_kernel_weight;
+        uniform sampler2D u_image;
+        uniform float[9] u_kernel;
+        uniform float u_kernel_weight;
 
-            in vec2 v_uv;
+        in vec2 v_uv;
 
-            out vec4 f_color;
+        out vec4 f_color;
 
-            void main() {
-                vec2 px = vec2(1) / vec2(textureSize(u_image, 0));
-                float[9] k = u_kernel;
-                vec4 color_sum =
-                    texture(u_image, px * vec2(-1, -1) + v_uv) * k[0] +
-                    texture(u_image, px * vec2( 0, -1) + v_uv) * k[1] +
-                    texture(u_image, px * vec2( 1, -1) + v_uv) * k[2] +
-                    texture(u_image, px * vec2(-1,  0) + v_uv) * k[3] +
-                    texture(u_image, px * vec2( 0,  0) + v_uv) * k[4] +
-                    texture(u_image, px * vec2( 1,  0) + v_uv) * k[5] +
-                    texture(u_image, px * vec2(-1,  1) + v_uv) * k[6] +
-                    texture(u_image, px * vec2( 0,  1) + v_uv) * k[7] +
-                    texture(u_image, px * vec2( 1,  1) + v_uv) * k[8] ;
-                f_color = vec4((color_sum / u_kernel_weight).rgb, 1.0);
-            }
+        void main() {
+            vec2 px = vec2(1) / vec2(textureSize(u_image, 0));
+            float[9] k = u_kernel;
+            vec4 color_sum =
+                texture(u_image, px * vec2(-1, -1) + v_uv) * k[0] +
+                texture(u_image, px * vec2( 0, -1) + v_uv) * k[1] +
+                texture(u_image, px * vec2( 1, -1) + v_uv) * k[2] +
+                texture(u_image, px * vec2(-1,  0) + v_uv) * k[3] +
+                texture(u_image, px * vec2( 0,  0) + v_uv) * k[4] +
+                texture(u_image, px * vec2( 1,  0) + v_uv) * k[5] +
+                texture(u_image, px * vec2(-1,  1) + v_uv) * k[6] +
+                texture(u_image, px * vec2( 0,  1) + v_uv) * k[7] +
+                texture(u_image, px * vec2( 1,  1) + v_uv) * k[8] ;
+            f_color = vec4((color_sum / u_kernel_weight).rgb, 1.0);
+        }
         `,
         {
             textures: { u_image: imageTexture },
@@ -107,7 +102,7 @@ async function run() {
                     type: "matrix4fv",
                     value: mat4.fromScaling(mat4.create(), [400, 400, 1]),
                 },
-                u_projection: {
+                u_proj: {
                     type: "matrix4fv",
                     value: mat4.ortho(
                         mat4.create(),

--- a/docs/instancing.ts
+++ b/docs/instancing.ts
@@ -24,47 +24,47 @@ import { mat4 } from "./libx/gl-matrix.js";
 const dev = Device.create();
 const [width, height] = [dev.canvasCSSWidth, dev.canvasCSSHeight];
 
-const view = mat4.identity(mat4.create());
+const viewMatrix = mat4.identity(mat4.create());
 
 // There is nothing special about this draw command. It uses 3 attributes and
-// does not actually know, that two of those are instanced.
+// does not actually know two of those are instanced.
 const cmd = Command.create(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        uniform mat4 u_projection;
-        uniform mat4 u_model;
-        uniform mat4 u_view;
+    uniform mat4 u_proj;
+    uniform mat4 u_model;
+    uniform mat4 u_view;
 
-        layout (location = 0) in vec2 a_position;
-        layout (location = 1) in vec2 a_offset;
-        layout (location = 2) in vec4 a_color;
+    layout (location = 0) in vec2 a_position;
+    layout (location = 1) in vec2 a_offset;
+    layout (location = 2) in vec4 a_color;
 
-        out vec4 v_vertex_color;
+    out vec4 v_vertex_color;
 
-        void main() {
-            v_vertex_color = a_color;
-            gl_Position = u_projection
-                * u_view
-                * u_model
-                * vec4(a_position + a_offset, 0.0, 1.0);
-        }
+    void main() {
+        v_vertex_color = a_color;
+        gl_Position = u_proj
+            * u_view
+            * u_model
+            * vec4(a_position + a_offset, 0.0, 1.0);
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        in vec4 v_vertex_color;
+    in vec4 v_vertex_color;
 
-        out vec4 f_color;
+    out vec4 f_color;
 
-        void main() {
-            f_color = v_vertex_color;
-        }
+    void main() {
+        f_color = v_vertex_color;
+    }
     `,
     {
         uniforms: {
-            u_projection: {
+            u_proj: {
                 type: "matrix4fv",
                 value: mat4.ortho(
                     mat4.create(),
@@ -82,7 +82,7 @@ const cmd = Command.create(
             },
             u_view: {
                 type: "matrix4fv",
-                value: () => mat4.rotateZ(view, view, 0.01),
+                value: () => mat4.rotateZ(viewMatrix, viewMatrix, 0.01),
             },
         },
     },
@@ -145,7 +145,7 @@ const attrs = Attributes.create(
     },
 );
 
-const loop = () => {
+const loop = (): void => {
     dev.target((rt) => {
         rt.clear(BufferBits.COLOR);
         rt.draw(cmd, attrs);

--- a/docs/life.ts
+++ b/docs/life.ts
@@ -66,63 +66,63 @@ interface CmdProps {
 const cmd = Command.create<CmdProps>(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        out vec2 v_uv;
+    out vec2 v_uv;
 
-        void main() {
-            switch (gl_VertexID % 3) {
-                case 0:
-                    gl_Position = vec4(-1, 3, 0, 1);
-                    v_uv = vec2(0, 2);
-                    break;
-                case 1:
-                    gl_Position = vec4(-1, -1, 0, 1);
-                    v_uv = vec2(0, 0);
-                    break;
-                case 2:
-                    gl_Position = vec4(3, -1, 0, 1);
-                    v_uv = vec2(2, 0);
-                    break;
-            }
+    void main() {
+        switch (gl_VertexID % 3) {
+            case 0:
+                gl_Position = vec4(-1, 3, 0, 1);
+                v_uv = vec2(0, 2);
+                break;
+            case 1:
+                gl_Position = vec4(-1, -1, 0, 1);
+                v_uv = vec2(0, 0);
+                break;
+            case 2:
+                gl_Position = vec4(3, -1, 0, 1);
+                v_uv = vec2(2, 0);
+                break;
         }
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        uniform sampler2D u_universe;
+    uniform sampler2D u_universe;
 
-        in vec2 v_uv;
+    in vec2 v_uv;
 
-        layout (location = 0) out float f_next_universe;
+    layout (location = 0) out float f_next_universe;
 
-        void main() {
-            vec2 px = vec2(1) / vec2(textureSize(u_universe, 0));
+    void main() {
+        vec2 px = vec2(1) / vec2(textureSize(u_universe, 0));
 
-            float current = texture(u_universe, v_uv).r;
-            float neighbors = 0.0;
+        float current = texture(u_universe, v_uv).r;
+        float neighbors = 0.0;
 
-            neighbors += texture(u_universe, px * vec2( 1,  1) + v_uv).r;
-            neighbors += texture(u_universe, px * vec2( 0,  1) + v_uv).r;
-            neighbors += texture(u_universe, px * vec2(-1,  1) + v_uv).r;
-            neighbors += texture(u_universe, px * vec2(-1,  0) + v_uv).r;
-            neighbors += texture(u_universe, px * vec2(-1, -1) + v_uv).r;
-            neighbors += texture(u_universe, px * vec2( 0, -1) + v_uv).r;
-            neighbors += texture(u_universe, px * vec2( 1, -1) + v_uv).r;
-            neighbors += texture(u_universe, px * vec2( 1,  0) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2( 1,  1) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2( 0,  1) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2(-1,  1) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2(-1,  0) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2(-1, -1) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2( 0, -1) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2( 1, -1) + v_uv).r;
+        neighbors += texture(u_universe, px * vec2( 1,  0) + v_uv).r;
 
-            if (current == 0.0) {
-                f_next_universe = neighbors == 3.0 ? 1.0 : 0.0;
+        if (current == 0.0) {
+            f_next_universe = neighbors == 3.0 ? 1.0 : 0.0;
+        } else {
+            if (neighbors >= 4.0) {
+                f_next_universe = 0.0;
+            } else if (neighbors >= 2.0) {
+                f_next_universe = 1.0;
             } else {
-                if (neighbors >= 4.0) {
-                    f_next_universe = 0.0;
-                } else if (neighbors >= 2.0) {
-                    f_next_universe = 1.0;
-                } else {
-                    f_next_universe = 0.0;
-                }
+                f_next_universe = 0.0;
             }
         }
+    }
     `,
     { textures: { u_universe: ({ tex }) => tex } },
 );
@@ -132,7 +132,7 @@ const attrs = Attributes.empty(dev, Primitive.TRIANGLES, 3);
 let ping = { tex: pingTex, fbo: pingFbo };
 let pong = { tex: pongTex, fbo: pongFbo };
 
-const loop = () => {
+const loop = (): void => {
     // Compute using previous values in ping, store to pong
     pong.fbo.target((rt) => {
         rt.draw(cmd, attrs, { tex: ping.tex });

--- a/docs/models.ts
+++ b/docs/models.ts
@@ -19,50 +19,50 @@ import * as teapot from "./libx/teapot.js";
 const dev = Device.create();
 const [width, height] = [dev.bufferWidth, dev.bufferHeight];
 
-const view = mat4.create();
+const viewMatrix = mat4.create();
 
 interface CmdProps {
     time: number;
-    matrix: mat4;
+    modelMatrix: mat4;
 }
 
 const cmd = Command.create<CmdProps>(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        uniform mat4 u_projection, u_view, u_model;
+    uniform mat4 u_proj, u_view, u_model;
 
-        layout (location = 0) in vec3 a_position;
-        layout (location = 1) in vec3 a_normal;
+    layout (location = 0) in vec3 a_position;
+    layout (location = 1) in vec3 a_normal;
 
-        out vec3 v_normal;
+    out vec3 v_normal;
 
-        void main() {
-            mat4 matrix = u_projection * u_view * u_model;
-            v_normal = transpose(inverse(mat3(matrix))) * a_normal;
-            gl_Position = matrix * vec4(a_position, 1.0);
-        }
+    void main() {
+        mat4 matrix = u_proj * u_view * u_model;
+        v_normal = transpose(inverse(mat3(matrix))) * a_normal;
+        gl_Position = matrix * vec4(a_position, 1.0);
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        uniform vec3 u_light;
+    uniform vec3 u_light;
 
-        in vec3 v_normal;
+    in vec3 v_normal;
 
-        out vec4 f_color;
+    out vec4 f_color;
 
-        void main() {
-            float brightness = dot(normalize(v_normal), normalize(u_light));
-            vec3 dark = vec3(0.3, 0.0, 0.3);
-            vec3 bright = vec3(1.0, 0.0, 0.8);
-            f_color = vec4(mix(dark, bright, brightness), 1.0);
-        }
+    void main() {
+        float brightness = dot(normalize(v_normal), normalize(u_light));
+        vec3 dark = vec3(0.3, 0.0, 0.3);
+        vec3 bright = vec3(1.0, 0.0, 0.8);
+        f_color = vec4(mix(dark, bright, brightness), 1.0);
+    }
     `,
     {
         uniforms: {
-            u_projection: {
+            u_proj: {
                 type: "matrix4fv",
                 value: mat4.perspective(
                     mat4.create(),
@@ -75,7 +75,7 @@ const cmd = Command.create<CmdProps>(
             u_view: {
                 type: "matrix4fv",
                 value: ({ time }) => mat4.lookAt(
-                    view,
+                    viewMatrix,
                     [
                         30 * Math.cos(time / 1000),
                         2.5,
@@ -87,7 +87,7 @@ const cmd = Command.create<CmdProps>(
             },
             u_model: {
                 type: "matrix4fv",
-                value: ({ matrix }) => matrix,
+                value: ({ modelMatrix }) => modelMatrix,
             },
             u_light: {
                 type: "3f",
@@ -103,11 +103,11 @@ const models = [teapot, bunny, cube];
 const objs = models.map((m, i) => {
     const angle = i / models.length * 2 * Math.PI;
     const scale = (i + 1) * 0.1;
-    const matrix = mat4.fromRotation(mat4.create(), angle, [0, 1, 0]);
-    mat4.translate(matrix, matrix, [4, 0, 0]);
-    mat4.scale(matrix, matrix, [scale, scale, scale]);
+    const modelMatrix = mat4.fromRotation(mat4.create(), angle, [0, 1, 0]);
+    mat4.translate(modelMatrix, modelMatrix, [4, 0, 0]);
+    mat4.scale(modelMatrix, modelMatrix, [scale, scale, scale]);
     return {
-        matrix,
+        modelMatrix,
         attrs: Attributes.create(dev, m.elements, {
             0: m.positions,
             1: m.normals,
@@ -115,12 +115,12 @@ const objs = models.map((m, i) => {
     };
 });
 
-const loop = (time) => {
+const loop = (time: number): void => {
     dev.target((rt) => {
         rt.clear(BufferBits.COLOR_DEPTH);
         rt.batch(cmd, (draw) => {
-            objs.forEach(({ attrs, matrix }) => {
-                draw(attrs, { time, matrix });
+            objs.forEach(({ attrs, modelMatrix }) => {
+                draw(attrs, { time, modelMatrix });
             });
         });
     });

--- a/docs/no-buffers.ts
+++ b/docs/no-buffers.ts
@@ -7,40 +7,40 @@ import { Device, Command, Attributes, Primitive } from "./lib/webglutenfree.js";
 
 const dev = Device.create();
 
-// This command uses gl_VertexID to determine, which vertex are we drawing. We
+// This command uses gl_VertexID to determine which vertex are we drawing. We
 // can think of the vertex shader as a functino that maps the vertex id to
 // real vertex (created on demand).
 const cmd = Command.create(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        out vec4 v_color;
+    out vec4 v_color;
 
-        const vec4[3] VERTICES = vec4[3] (
-            vec4(-0.9, -0.5, 0, 1),
-            vec4(-0.3, -0.5, 0, 1),
-            vec4(-0.6, 0.5, 0, 1)
-        );
+    const vec4[3] VERTICES = vec4[3] (
+        vec4(-0.9, -0.5, 0, 1),
+        vec4(-0.3, -0.5, 0, 1),
+        vec4(-0.6, 0.5, 0, 1)
+    );
 
-        void main() {
-            int vid = gl_VertexID % 3;
-            int cid = (gl_VertexID + 1) % 3;
-            v_color = vec4(0, 0, 0, 1);
-            v_color[cid] = 1.0;
-            gl_Position = 0.1 * float(gl_VertexID / 3) + VERTICES[vid];
-        }
+    void main() {
+        int vid = gl_VertexID % 3;
+        int cid = (gl_VertexID + 1) % 3;
+        v_color = vec4(0, 0, 0, 1);
+        v_color[cid] = 1.0;
+        gl_Position = 0.1 * float(gl_VertexID / 3) + VERTICES[vid];
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        in vec4 v_color;
+    in vec4 v_color;
 
-        out vec4 f_color;
+    out vec4 f_color;
 
-        void main() {
-            f_color = v_color;
-        }
+    void main() {
+        f_color = v_color;
+    }
     `,
 );
 

--- a/docs/smoothlife.ts
+++ b/docs/smoothlife.ts
@@ -70,105 +70,102 @@ interface CmdProps {
 const cmd = Command.create<CmdProps>(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        out vec2 v_uv;
+    out vec2 v_uv;
 
-        void main() {
-            switch (gl_VertexID % 3) {
-                case 0:
-                    gl_Position = vec4(-1, 3, 0, 1);
-                    v_uv = vec2(0, 2);
-                    break;
-                case 1:
-                    gl_Position = vec4(-1, -1, 0, 1);
-                    v_uv = vec2(0, 0);
-                    break;
-                case 2:
-                    gl_Position = vec4(3, -1, 0, 1);
-                    v_uv = vec2(2, 0);
-                    break;
-            }
+    void main() {
+        switch (gl_VertexID % 3) {
+            case 0:
+                gl_Position = vec4(-1, 3, 0, 1);
+                v_uv = vec2(0, 2);
+                break;
+            case 1:
+                gl_Position = vec4(-1, -1, 0, 1);
+                v_uv = vec2(0, 0);
+                break;
+            case 2:
+                gl_Position = vec4(3, -1, 0, 1);
+                v_uv = vec2(2, 0);
+                break;
         }
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        #define WIDTH ${WIDTH}
-        #define HEIGHT ${HEIGHT}
-        #define KERNEL_RADIUS ${KERNEL_RADIUS}
-        #define INNER_RADIUS ${INNER_RADIUS}
-        #define OUTER_RADIUS ${OUTER_RADIUS}
-        #define BIRTH_LO ${BIRTH_LO}
-        #define BIRTH_HI ${BIRTH_HI}
-        #define DEATH_LO ${DEATH_LO}
-        #define DEATH_HI ${DEATH_HI}
-        #define ALPHA_N ${ALPHA_N}
-        #define ALPHA_M ${ALPHA_M}
+    const int WIDTH = int(${WIDTH});
+    const int HEIGHT = int(${HEIGHT});
+    const int KERNEL_RADIUS = int(${KERNEL_RADIUS});
+    const float INNER_RADIUS = float(${INNER_RADIUS});
+    const float OUTER_RADIUS = float(${OUTER_RADIUS});
+    const float BIRTH_LO = float(${BIRTH_LO});
+    const float BIRTH_HI = float(${BIRTH_HI});
+    const float DEATH_LO = float(${DEATH_LO});
+    const float DEATH_HI = float(${DEATH_HI});
+    const float ALPHA_N = float(${ALPHA_N});
+    const float ALPHA_M = float(${ALPHA_M});
 
-        uniform sampler2D u_universe;
+    uniform sampler2D u_universe;
 
-        in vec2 v_uv;
+    in vec2 v_uv;
 
-        layout (location = 0) out vec4 f_next_universe;
+    layout (location = 0) out vec4 f_next_universe;
 
-        float f(vec2 c) {
-            return texture(u_universe, v_uv + (c / vec2(WIDTH, HEIGHT))).r;
-        }
+    float f(vec2 c) {
+        return texture(u_universe, v_uv + (c / vec2(WIDTH, HEIGHT))).r;
+    }
 
-        float sigma_1(float x, float a, float alpha) {
-            return 1.0 / (1.0 + exp(-(x - a) * 4.0 / alpha));
-        }
+    float sigma_1(float x, float a, float alpha) {
+        return 1.0 / (1.0 + exp(-(x - a) * 4.0 / alpha));
+    }
 
-        float sigma_n(float x, float a, float b) {
-            return sigma_1(x, a, ALPHA_N) * (1.0 - sigma_1(x, b, ALPHA_N));
-        }
+    float sigma_n(float x, float a, float b) {
+        return sigma_1(x, a, ALPHA_N) * (1.0 - sigma_1(x, b, ALPHA_N));
+    }
 
-        float sigma_m(float x, float y, float m) {
-            float s1 = sigma_1(m, 0.5, ALPHA_M);
-            return x * (1.0 - s1) + y * s1;
-        }
+    float sigma_m(float x, float y, float m) {
+        float s1 = sigma_1(m, 0.5, ALPHA_M);
+        return x * (1.0 - s1) + y * s1;
+    }
 
-        float S(float n, float m) {
-            return sigma_n(
-                n,
-                sigma_m(BIRTH_LO, DEATH_LO, m),
-                sigma_m(BIRTH_HI, DEATH_HI, m)
-            );
-        }
+    float S(float n, float m) {
+        return sigma_n(
+            n,
+            sigma_m(BIRTH_LO, DEATH_LO, m),
+            sigma_m(BIRTH_HI, DEATH_HI, m)
+        );
+    }
 
-        float weight(float r, float cutoff) {
-            return 1.0 - sigma_1(r, cutoff, 0.5);
-        }
+    float weight(float r, float cutoff) {
+        return 1.0 - sigma_1(r, cutoff, 0.5);
+    }
 
-        void main() {
-            float IR = float(INNER_RADIUS);
-            float OR = float(OUTER_RADIUS);
+    void main() {
+        float r1 = 0.0;
+        float r2 = 0.0;
+        float w1 = 0.0;
+        float w2 = 0.0;
 
-            float r1 = 0.0;
-            float r2 = 0.0;
-            float w1 = 0.0;
-            float w2 = 0.0;
+        for (int i = -KERNEL_RADIUS; i <= KERNEL_RADIUS; ++i) {
+            for (int j = -KERNEL_RADIUS; j <= KERNEL_RADIUS; ++j) {
+                float s = f(vec2(i, j));
+                float r = sqrt(float(i*i + j*j));
 
-            for (int i = -KERNEL_RADIUS; i <= KERNEL_RADIUS; ++i) {
-                for (int j = -KERNEL_RADIUS; j <= KERNEL_RADIUS; ++j) {
-                    float s = f(vec2(i, j));
-                    float r = sqrt(float(i*i + j*j));
-
-                    float wi = weight(r, IR);
-                    r1 += s * wi;
-                    w1 += wi;
-                    float wo = weight(r, OR);
-                    r2 += s * wo;
-                    w2 += wo;
-                }
+                float wi = weight(r, INNER_RADIUS);
+                r1 += s * wi;
+                w1 += wi;
+                float wo = weight(r, OUTER_RADIUS);
+                r2 += s * wo;
+                w2 += wo;
             }
-
-            float m = r1 / w1;
-            float n = (r2 - r1) / (w2 - w1);
-
-            f_next_universe = vec4(S(n, m), m, n, 1);
         }
+
+        float m = r1 / w1;
+        float n = (r2 - r1) / (w2 - w1);
+
+        f_next_universe = vec4(S(n, m), m, n, 1);
+    }
     `,
     { textures: { u_universe: ({ tex }) => tex } },
 );
@@ -178,7 +175,7 @@ const attrs = Attributes.empty(dev, Primitive.TRIANGLES, 3);
 let ping = { tex: pingTex, fbo: pingFbo };
 let pong = { tex: pongTex, fbo: pongFbo };
 
-const loop = () => {
+const loop = (): void => {
     // Compute using previous values in ping, store to pong
     pong.fbo.target((rt) => {
         rt.draw(cmd, attrs, { tex: ping.tex });

--- a/docs/triangle.ts
+++ b/docs/triangle.ts
@@ -22,28 +22,28 @@ const dev = Device.create();
 const cmd = Command.create(
     dev,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        layout (location = 0) in vec2 a_position;
-        layout (location = 1) in vec4 a_color;
+    layout (location = 0) in vec2 a_position;
+    layout (location = 1) in vec4 a_color;
 
-        out vec4 v_color;
+    out vec4 v_color;
 
-        void main() {
-            v_color = a_color;
-            gl_Position = vec4(a_position, 0.0, 1.0);
-        }
+    void main() {
+        v_color = a_color;
+        gl_Position = vec4(a_position, 0.0, 1.0);
+    }
     `,
     `#version 300 es
-        precision mediump float;
+    precision mediump float;
 
-        in vec4 v_color;
+    in vec4 v_color;
 
-        layout (location = 0) out vec4 f_color;
+    layout (location = 0) out vec4 f_color;
 
-        void main() {
-            f_color = v_color;
-        }
+    void main() {
+        f_color = v_color;
+    }
     `,
 );
 


### PR DESCRIPTION
Changes:
- shader indentation
- get rid of `#define`s in favor of `const`s
- add declarations to non-inline arrow function defs
- unify matrix naming 